### PR TITLE
flip card's bullet lists are aligned in services page

### DIFF
--- a/services.html
+++ b/services.html
@@ -90,6 +90,7 @@
             /* margin: -2px; */
             font-weight: bolder;
             color: black;
+            text-align: left;
         }
         
         .cardplong {
@@ -207,7 +208,8 @@
                             </div>
 
                         </div>
-                        <div class="flip-card-back" style="background-color:#ebc0c0;">
+                        <div class="flip-card-back" style="background-color:#ebc0c0;text-align: left;
+                        ">
                             <ul style="list-style-type:disc; color: black;">
                                 <li>
                                     <p class="cardplong">Equity Advisory Services</p>


### PR DESCRIPTION
### Suggestions
        The bullet lists in the flip cards of service page are not aligned, seems unorganized. Firebase key's are added in  in public repositories which is not safe.

## Description
 In the Service page,  the bullet lists of the flip card are not aligned. I aligned the list in organized manner by reducing space from left hand side.
Here is comparison between cards have aligned and non aligned bullet lists

  ## Non Aligned bullet lists
![images (1)](https://user-images.githubusercontent.com/85214168/135586805-a552dbd7-2663-4fa2-8db1-2799d51f2570.png) ![21_2](https://user-images.githubusercontent.com/85214168/135587022-6e4e25e5-1f69-4fc2-826b-7de29f337758.png)
 
## Aligned bullet lists
 ![21](https://user-images.githubusercontent.com/85214168/135586864-4d69d907-346c-4649-afc5-0a6a69426a9f.png) ![11](https://user-images.githubusercontent.com/85214168/135587032-dc5a4bdb-cefe-4198-90b1-3f4b80e28d30.jpeg)




